### PR TITLE
[PLTF-1607] Docker image push support

### DIFF
--- a/artifact-management/commands/docker-build-and-push.yml
+++ b/artifact-management/commands/docker-build-and-push.yml
@@ -1,0 +1,35 @@
+description: Builds and pushes a Docker image to one or more Docker repositories
+parameters:
+  docker_build_command:
+    description: The command to be used to build the Docker image
+    type: string
+    default: |-
+        docker build \
+          --build-arg SOURCE_COMMIT=$CIRCLE_SHA \
+          --build-arg PACKAGECLOUD_NPM_READ_TOKEN=$PACKAGECLOUD_NPM_READ_TOKEN \
+          --build-arg PACKAGECLOUD_READ_TOKEN=$PACKAGELOUD_READ_TOKEN \
+          -t avvo/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1 \
+          .
+  docker_build_dir:
+    description: The directory in which the gem build and push should run
+    type: string
+    default: .
+  docker_repo_host:
+    description: The private Docker repo to which images should be pushed
+    type: env_var_name
+    default: AVVO_DOCKER_REPO_HOST
+  packagecloud_npm_read_token:
+    description: The token to be used when fetching NPM packages from Packagecloud
+    type: env_var_name
+    default: PACKAGECLOUD_NPM_READ_TOKEN
+  packagecloud_read_token:
+    description: The token to be used when fetching packages from Packagecloud
+    type: env_var_name
+    default: PACKAGECLOUD_READ_TOKEN
+steps:
+  - setup-docker-environment
+  - docker-build:
+      docker_build_dir: <<parameters.docker_build_dir>>
+      docker_build_command: <<parameters.docker_build_command>>
+  - docker-push
+  - teardown-docker-environment

--- a/artifact-management/commands/docker-build.yml
+++ b/artifact-management/commands/docker-build.yml
@@ -1,0 +1,30 @@
+description: Perform the actual docker build
+parameters:
+  docker_build_command:
+    description: The command to be used to build the Docker image
+    type: string
+    default: |-
+        docker build \
+          --build-arg SOURCE_COMMIT=$CIRCLE_SHA \
+          --build-arg PACKAGECLOUD_NPM_READ_TOKEN=$PACKAGECLOUD_NPM_READ_TOKEN \
+          --build-arg PACKAGECLOUD_READ_TOKEN=$PACKAGELOUD_READ_TOKEN \
+          -t avvo/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1 \
+          .
+  docker_build_dir:
+    description: The directory in which the gem build and push should run
+    type: string
+    default: .
+  packagecloud_npm_read_token:
+    description: The token to be used when fetching NPM packages from Packagecloud
+    type: env_var_name
+    default: PACKAGECLOUD_NPM_READ_TOKEN
+  packagecloud_read_token:
+    description: The token to be used when fetching packages from Packagecloud
+    type: env_var_name
+    default: PACKAGECLOUD_READ_TOKEN
+steps:
+  - run:
+      name: Build docker image
+      command: |-
+        cd <<parameters.docker_build_dir>>
+        <<parameters.docker_build_command>>

--- a/artifact-management/commands/docker-push.yml
+++ b/artifact-management/commands/docker-push.yml
@@ -1,0 +1,26 @@
+description: Push built Docker images to repo host(s)
+parameters:
+  docker_repo_host:
+    description: The private Docker repo to which images should be pushed
+    type: env_var_name
+    default: AVVO_DOCKER_REPO_HOST
+steps:
+  - run:
+      name: Publish tagged image
+      command: |-
+        set -x
+
+        TAG=avvo/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+
+        # Log in to Dockerhub and push
+        if [ -n "$DOCKER_USER" ]; then
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker push $TAG
+        fi
+
+        # Push to private Docker repo
+        if [ -n "$AVVO_DOCKER_REPO_HOST" ]; then
+          docker tag $TAG $AVVO_DOCKER_REPO_HOST/$TAG
+          docker login -u $AVVO_DOCKER_REPO_USER -p $AVVO_DOCKER_REPO_PASS $AVVO_DOCKER_REPO_HOST
+          docker push $AVVO_DOCKER_REPO_HOST/$TAG
+        fi

--- a/artifact-management/commands/setup-docker-environment.yml
+++ b/artifact-management/commands/setup-docker-environment.yml
@@ -1,0 +1,21 @@
+description: Prepares the local environment for building and pushing Docker images
+steps:
+  - setup_remote_docker:
+      docker_layer_caching: true
+  - run:
+      name: Install Docker client
+      command: |-
+        set -x
+        if [ ! -f /usr/bin/docker ]; then
+          VER="19.03.9"
+          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
+          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+          mv /tmp/docker/* /usr/bin
+        fi
+  - run:
+      name: Record remote Docker IP address required for proxy access
+      command: |-
+        # capture IP address of docker remote engine, put it in environment variable
+        # $IP that will be accessible to any tasks run after this one.
+        echo "export IP=$(ssh remote-docker wget -q -O - ifconfig.me)" >> $BASH_ENV
+  - setup-generic-environment

--- a/artifact-management/commands/teardown-docker-environment.yml
+++ b/artifact-management/commands/teardown-docker-environment.yml
@@ -1,0 +1,3 @@
+description: Cleans up after building and pushing Docker images
+steps:
+  - teardown-generic-environment


### PR DESCRIPTION
This PR adds support for the following orb commands:

* `artifact-management/docker-build-and-push` (see https://github.com/avvo/account/pull/62 for an example)
* Its related sub-commands:
** `artifact-management/setup-docker-environment`
** `artifact-management/docker-build`
** `artifact-management/docker-push`
** `artifact-management/teardown-docker-environment`

The default behavior is to do the following:
- Run `setup-remote-docker` and install the Docker client utilities if they are not already installed
- Register the IP address of the remote Docker engine, for use by `avvo/aws-white-list-circleci-ip` to open repository firewall holes as needed
- Build the targeted Docker image. The `docker_build_command` parameter allows a lot of flexibilty here
- Push the Docker image to Dockerhub (if `DOCKER_USER` is defined) and/or a private repository (if `AVVO_DOCKER_REPO_HOST` is defined)
- Clean up the firewall holes as needed
