### PR TITLE
gem-test refactor to allow intermediate commands.

### DIFF
--- a/artifact-management/commands/gem-test-core.yml
+++ b/artifact-management/commands/gem-test-core.yml
@@ -1,0 +1,130 @@
+description: Implements commands to run default Ruby version tests, or
+  multiple test with Ruby versions specified through ruby_versions parameter.
+parameters:
+  bundler_1_version:
+    description: The precise Bundler 1.x version that should be used
+      for "bundle install" and the actual test command.
+    type: string
+    default: 1.17.3
+  bundler_2_version:
+    description: The precise Bundler 2.x version that should be used
+      for "bundle install" and the actual test command.
+    type: string
+    default: 2.1.4
+  bundler_install_command:
+    description: The command that should be used to run bundle installtions.
+    type: string
+    default: bundle install
+  gem_test_dir:
+    description: The directory in which the gem tests should run.
+    type: string
+    default: .
+  post_gem_test_conditions:
+    description: Steps that must be true after all test steps. For example
+      if you need to create test reports.
+    type: steps
+    default: []
+  post_test_command:
+    description: Command that will be executed after test_command. For
+      example if you need to remove any residual file created by the test
+      command. This command is executed for each Ruby version.
+    type: string
+    default: echo "No post test process command."
+  pre_bundler_install_command:
+    description: Command that will be executed before bundler_install_command.
+      For example if you need to remove Gemfile.lock before "bundle install" is
+      executed. This command is executed for each Ruby version.
+    type: string
+    default: echo "No pre bundler install command."
+  pre_gem_test_conditions:
+    description: Steps that must be true before all test steps. For example
+      if you need to install gems. This steps are executed once for all Ruby
+      versions.
+    type: steps
+    default: []
+  pre_test_command:
+    description: Command that will be executed just before test_command. For
+      example if you need to prepare test DB after "bundle install" and
+      before "rake test"
+    type: string
+    default: echo "No pre test command."
+  ruby_versions:
+    description: The ruby versions to be used to test the gem. If set, RVM is
+      assumed to be installed and the install/test commands will be prefaced
+      with rvm <<ruby_versions> do .... If unset (the default), the system
+      ruby will be called directly.
+    type: string
+    default: ""
+  test_command:
+    default: bundle exec rake test
+    description: The command that should be used to run tests.
+    type: string
+steps:
+  - when:
+      condition: <<parameters.ruby_versions>>
+      steps:
+        - steps: << parameters.pre_gem_test_conditions >>
+
+        - run:
+            name: Install bundler gem
+            command: |-
+              for v in $(echo "<<parameters.ruby_versions>>" | sed "s/,/ /g");
+              do \
+                MAJOR=$(echo $v | cut -f 1 -d'.')
+                MINOR=$(echo $v | cut -f 2 -d'.')
+                if [[ $MAJOR -ge 3 || ( $MAJOR -eq 2 && $MINOR -ge 7 ) ]];
+                then
+                  echo "Installing bundler version 2 for Ruby version $v"
+                  rvm $v do gem install bundler --version=<<parameters.bundler_2_version>>
+                else
+                  echo "Installing bundler version 1 for Ruby version $v"
+                  rvm $v do gem install bundler --version=<<parameters.bundler_1_version>>
+                fi \
+              done
+
+        - run:
+            name: Test process
+            command: |-
+              cd <<parameters.gem_test_dir>>
+              for v in $(echo "<<parameters.ruby_versions>>" | sed "s/,/ /g");
+              do \
+                 echo "Test process for Ruby $v"
+                 rvm $v do <<parameters.pre_bundler_install_command>>
+                 rvm $v do <<parameters.bundler_install_command>>
+                 rvm $v do <<parameters.pre_test_command>>
+                 rvm $v do <<parameters.test_command>>
+                 rvm $v do <<parameters.post_test_command>>
+              done
+
+        - steps: << parameters.post_gem_test_conditions >>
+
+  - unless:
+     condition: <<parameters.ruby_versions>>
+     steps:
+       - steps: << parameters.pre_gem_test_conditions >>
+
+       - run:
+           name: Install bundler gem
+           command: |-
+             RUBY_VERSION=$(ruby --version | cut -f 2 -d' ')
+             MAJOR=$(echo $RUBY_VERSION | cut -f 1 -d'.')
+             MINOR=$(echo $RUBY_VERSION | cut -f 2 -d'.')
+             if [[ $MAJOR -ge 3 || ( $MAJOR -eq 2 && $MINOR -ge 7 ) ]];
+             then
+               echo "Installing bundler version 2 for Ruby version $RUBY_VERSION"
+               gem install bundler --version=<<parameters.bundler_2_version>>
+             else
+               echo "Installing bundler version 1 for Ruby version $RUBY_VERSION"
+               gem install bundler --version=<<parameters.bundler_1_version>>
+             fi
+
+       - run:
+           name: Test process
+           command: |-
+             <<parameters.pre_bundler_install_command>>
+             <<parameters.bundler_install_command>>
+             <<parameters.pre_test_command>>
+             <<parameters.test_command>>
+             <<parameters.post_test_command>>
+
+       - steps: << parameters.post_gem_test_conditions >>

--- a/artifact-management/commands/gem-test.yml
+++ b/artifact-management/commands/gem-test.yml
@@ -12,6 +12,10 @@ parameters:
       for "bundle install" and the actual test command.
     type: string
     default: 2.1.4
+  bundler_install_command:
+    description: The command that should be used to run bundle installtions.
+    type: string
+    default: bundle install
   gem_repo_host:
     description: The host to which built packages should be pushed.
     type: env_var_name
@@ -24,6 +28,35 @@ parameters:
     description: The directory in which the gem tests should run.
     type: string
     default: .
+  post_gem_test_conditions:
+    description: Steps that must be true after all test steps. For example
+      if you need to create test reports.
+    type: steps
+    default: []
+  post_test_command:
+    description: Command that will be executed after test_command. For
+      example if you need to remove any residual file created by the test
+      command. This command is executed for each Ruby version.
+    type: string
+    default: echo "No post test process command."
+  pre_bundler_install_command:
+    description: Command that will be executed before bundler_install_command.
+      For example if you need to remove Gemfile.lock before "bundle install" is
+      executed. This command is executed for each Ruby version.
+    type: string
+    default: echo "No pre bundler install command."
+  pre_gem_test_conditions:
+    description: Steps that must be true before all test steps. For example
+      if you need to install gems. This steps are executed once for all Ruby
+      versions.
+    type: steps
+    default: []
+  pre_test_command:
+    description: Command that will be executed just before test_command. For
+      example if you need to prepare test DB after "bundle install" and
+      before "rake test"
+    type: string
+    default: echo "No pre test command."
   packagecloud_read_token:
     description: The token to be used when fetching packages from Packagecloud.
     type: env_var_name
@@ -41,61 +74,16 @@ parameters:
     type: string
 steps:
   - setup-gem-environment
-  - when:
-      condition: <<parameters.ruby_versions>>
-      steps:
-        - run:
-            name: Install bundler gem
-            command: |-
-              for v in $(echo "<<parameters.ruby_versions>>" | sed "s/,/ /g");
-              do \
-                MAJOR=$(echo $v | cut -f 1 -d'.')
-                MINOR=$(echo $v | cut -f 2 -d'.')
-                if [[ $MAJOR -ge 3 || ( $MAJOR -eq 2 && $MINOR -ge 7 ) ]];
-                then
-                  echo "Installing bundler version 2 for Ruby version $v"
-                  rvm $v do gem install bundler --version=<<parameters.bundler_2_version>>
-                else
-                  echo "Installing bundler version 1 for Ruby version $v"
-                  rvm $v do gem install bundler --version=<<parameters.bundler_1_version>>
-                fi \
-              done
-        - run:
-            name: bundle install
-            command: |-
-              cd <<parameters.gem_test_dir>>
-              rvm <<parameters.ruby_versions>> do bundle install
-        - run:
-            name: Run tests
-            command: |-
-              cd <<parameters.gem_test_dir>>
-              rvm <<parameters.ruby_versions>> do <<parameters.test_command>>
-  - unless:
-     condition: <<parameters.ruby_versions>>
-     steps:
-       - run:
-           name: Install bundler gem
-           command: |-
-             RUBY_VERSION=$(ruby --version | cut -f 2 -d' ')
-             MAJOR=$(echo $RUBY_VERSION | cut -f 1 -d'.')
-             MINOR=$(echo $RUBY_VERSION | cut -f 2 -d'.')
-             if [[ $MAJOR -ge 3 || ( $MAJOR -eq 2 && $MINOR -ge 7 ) ]];
-             then
-               echo "Installing bundler version 2 for Ruby version $RUBY_VERSION"
-               gem install bundler --version=<<parameters.bundler_2_version>>
-             else
-               echo "Installing bundler version 1 for Ruby version $RUBY_VERSION"
-               gem install bundler --version=<<parameters.bundler_1_version>>
-             fi
-       - run:
-           name: bundle install
-           command: |-
-             cd <<parameters.gem_test_dir>>
-             bundle install
-       - run:
-           name: Run tests
-           command: |-
-             cd <<parameters.gem_test_dir>>
-             <<parameters.test_command>>
-
+  - gem-test-core:
+      bundler_1_version: <<parameters.bundler_1_version>>
+      bundler_2_version: <<parameters.bundler_2_version>>
+      bundler_install_command: <<parameters.bundler_install_command>>
+      gem_test_dir: <<parameters.gem_test_dir>>
+      post_gem_test_conditions: <<parameters.post_gem_test_conditions>>
+      post_test_command: <<parameters.post_test_command>>
+      pre_bundler_install_command: <<parameters.pre_bundler_install_command>>
+      pre_gem_test_conditions: <<parameters.pre_gem_test_conditions>>
+      pre_test_command: <<parameters.pre_test_command>>
+      ruby_versions: <<parameters.ruby_versions>>
+      test_command: <<parameters.test_command>>
   - teardown-gem-environment


### PR DESCRIPTION
I am proposing you this PR to improve gem-test as we talked some days ago. I am also working in parallel with improvements to docker's targets; but I'm not proposing then in this PR because I believe I need more experience with applications issues before those improvements are mature. 
Next is a list with the benefits of this new version. What you think?

1) Do not require to change CircleCi's configuration for gem already working with version 0.0.6.

2) Allows to introduce unexpected steps directly or through parameters while keep using the core logic of the "test process". For example:
Before:
```
      - artifact-management/setup-gem-environment

      - restore_cache:
          keys:
            - avvo-models-{{ checksum "Gemfile.lock" }}

      - run:
          name: Install Bundler
          command: rvm 2.3.8,2.4.10,2.5.8,2.6.6 do gem install bundler --version=1.17.3

      - run:
          name: Install Ruby Dependencies
          command: rvm 2.3.8,2.4.10,2.5.8,2.6.6 do bundle install --jobs=4 --retry=3

      - run:
          name: Prepare database
          command: |
            bundle exec rake db:setup RACK_ENV=test

      - run:
          name: Run tests
          command: rvm 2.3.8,2.4.10,2.5.8,2.6.6 do bundle exec rake test

      - save_cache:
          key: avvo-models-{{ checksum "Gemfile.lock" }}
          paths:
            - vendor/bundle

      - artifact-management/teardown-gem-environment
```
After. There are two alternatives with new code:
1) Is possible to use gem-test target in more fine grain basis and reutilize the core logic of the "test process".
```
      - artifact-management/setup-gem-environment

      - restore_cache:
          keys:
            - avvo-models-{{ checksum "Gemfile.lock" }}

      - gem-test-core:
            pre_test_command: bundle exec rake db:setup RACK_ENV=test$
            ruby_versions: "2.2.10,2.3.8,2.4.10,2.5.8,2.6.6"

      - save_cache:
          key: avvo-models-{{ checksum "Gemfile.lock" }}
          paths:
            - vendor/bundle

      - artifact-management/teardown-gem-environment
```
2) Is possible to control the all process through parameters.
```
      - gem-test:
	   pre_gem_test_conditions:
               - restore_cache:
                   keys:
                     - avvo-models-{{ checksum "Gemfile.lock" }}

           pre_test_command: bundle exec rake db:setup RACK_ENV=test$

           ruby_versions: "2.2.10,2.3.8,2.4.10,2.5.8,2.6.6"

           post_gem_test_conditions:
               - save_cache:
                   key: avvo-models-{{ checksum "Gemfile.lock" }}
                   paths:
                    - vendor/bundle
```
3) Each Ruby version encapsulated the core logic of the "test process": All the output belonging to commands of a same Ruby version is together.
Before
```
output for bundle install for Ruby 2.2.x
output for bundle install for Ruby 2.3.x
...
output for bundle exec rake test for Ruby 2.2.x
output for bundle exec rake test for Ruby 2.3.x
...
```
After
```
Test process for Ruby 2.2.x
output for bundle install
output for bundle exec rake test

Test process for Ruby 2.3.x
output for bundle install
output for bundle exec rake test
...
```