### PR TITLE
Fix missing change directory.

### DIFF
--- a/artifact-management/commands/gem-test-core.yml
+++ b/artifact-management/commands/gem-test-core.yml
@@ -121,6 +121,7 @@ steps:
        - run:
            name: Test process
            command: |-
+             cd <<parameters.gem_test_dir>>
              <<parameters.pre_bundler_install_command>>
              <<parameters.bundler_install_command>>
              <<parameters.pre_test_command>>


### PR DESCRIPTION
With shame I confess to having forgotten the directory change command for the case in which multiple versions of ruby are not used. 