### PR TITLE
Add login to dockerhub in setup-docker-environment.

### DIFF
--- a/artifact-management/commands/setup-docker-environment.yml
+++ b/artifact-management/commands/setup-docker-environment.yml
@@ -18,4 +18,11 @@ steps:
         # capture IP address of docker remote engine, put it in environment variable
         # $IP that will be accessible to any tasks run after this one.
         echo "export IP=$(ssh remote-docker wget -q -O - ifconfig.me)" >> $BASH_ENV
+  - run:
+      name: Login to Dockerhub
+      command: |-
+        # Log in to Dockerhub
+        if [ -n "$DOCKER_USER" ]; then
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+        fi
   - setup-generic-environment


### PR DESCRIPTION
From what have been discuss [here](https://github.com/avvo/content/pull/182) this PR implements a solution when need to login to dockerhub prior to build the image:

- In [this example](https://app.circleci.com/pipelines/github/avvo/gnomon/36/workflows/12f33b39-23a2-4e19-8081-68d255f06ca4/jobs/474) artifact-management/docker-build-and-push target is used and the job fails because can not access Avvo's repositories at dockerhub.

- In [this example](https://app.circleci.com/pipelines/github/avvo/gnomon/37/workflows/25ae28be-673e-4bb8-a4ec-b78bde0a390a/jobs/476) the same code result in a success job using the proposed modification to the orb's target.